### PR TITLE
[Selenium] Use direct link to return fleet

### DIFF
--- a/selenium/src/main/scala/not/ogame/bots/selenium/SeleniumOgameDriver.scala
+++ b/selenium/src/main/scala/not/ogame/bots/selenium/SeleniumOgameDriver.scala
@@ -326,8 +326,9 @@ class SeleniumOgameDriver[F[_]: Sync](credentials: Credentials)(implicit webDriv
 
   override def returnFleet(fleetId: FleetId): F[Unit] = {
     Sync[F].delay {
-      webDriver.get(s"https://${credentials.universeId}.ogame.gameforge.com/game/index.php?page=ingame&component=movement")
-      webDriver.findElement(By.id(fleetId)).findElement(By.className("reversal")).click()
+      webDriver.get(
+        s"https://${credentials.universeId}.ogame.gameforge.com/game/index.php?page=ingame&component=movement&return=${fleetId.filter(_.isDigit)}"
+      )
     }
   }
 


### PR DESCRIPTION
In oposition to clicking on element this does not require scrolling